### PR TITLE
Some suggested changes for review

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -87,41 +87,32 @@ class AppWindow:
 
         frame = ttk.Frame(self.w, name=appname.lower())
         frame.grid(sticky=tk.NSEW)
-        rows = 4
-        plugin_items = list()
-        for plugname in plug.PLUGINS:
-            appitem = plug.get_plugin_app(plugname, frame)
-            if appitem:
-                plugin_items.append(appitem)
-
-        rows += len(plugin_items)
-
         frame.columnconfigure(1, weight=1)
-        frame.rowconfigure(rows, weight=1)
 
         ttk.Label(frame, text=_('Cmdr')+':').grid(row=0, column=0, sticky=tk.W)	# Main window
         ttk.Label(frame, text=_('System')+':').grid(row=1, column=0, sticky=tk.W)	# Main window
         ttk.Label(frame, text=_('Station')+':').grid(row=2, column=0, sticky=tk.W)	# Main window
 
-        nextrow = 3
-        for plugin_item in plugin_items:
-            plugin_item.grid(row=nextrow, column=0, sticky=tk.W)
-            nextrow += 1
-
         self.cmdr = ttk.Label(frame, width=-21)
         self.system =  HyperlinkLabel(frame, compound=tk.RIGHT, url = self.system_url, popup_copy = True)
         self.station = HyperlinkLabel(frame, url = self.station_url, popup_copy = lambda x: x!=self.STATION_UNDOCKED)
-        self.button = ttk.Button(frame, name='update', text=_('Update'), command=self.getandsend, default=tk.ACTIVE, state=tk.DISABLED)	# Update button in main window
-        self.status = ttk.Label(frame, name='status', width=-25)
-        self.w.bind('<Return>', self.getandsend)
-        self.w.bind('<KP_Enter>', self.getandsend)
 
         self.cmdr.grid(row=0, column=1, sticky=tk.EW)
         self.system.grid(row=1, column=1, sticky=tk.EW)
         self.station.grid(row=2, column=1, sticky=tk.EW)
 
-        self.button.grid(row=nextrow + 1, column=0, columnspan=2, sticky=tk.NSEW)
-        self.status.grid(row=nextrow + 2, column=0, columnspan=2, sticky=tk.EW)
+        for plugname in plug.PLUGINS:
+            appitem = plug.get_plugin_app(plugname, frame)
+            if appitem:
+                appitem.grid(columnspan=2, sticky=tk.W)
+
+        self.button = ttk.Button(frame, name='update', text=_('Update'), command=self.getandsend, default=tk.ACTIVE, state=tk.DISABLED)	# Update button in main window
+        self.status = ttk.Label(frame, name='status', width=-25)
+        self.button.grid(columnspan=2, sticky=tk.NSEW)
+        self.status.grid(columnspan=2, sticky=tk.EW)
+
+        self.w.bind('<Return>', self.getandsend)
+        self.w.bind('<KP_Enter>', self.getandsend)
 
         for child in frame.winfo_children():
             child.grid_configure(padx=5, pady=(platform=='darwin' and 3 or 2))

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -61,8 +61,7 @@ plugin_app.status['text'] = "Status: Happy!"
 
 ## Events
 
-Once you have created your plugin and EDMC has loaded it there in addition to the `plugin_prefs()` and `plugin_app()` functions there are two other functions you can define to be notified by EDMC when something happens. 
-`system_changed()` and `cmdr_data()`.
+Once you have created your plugin and EDMC has loaded it there are two other functions you can define to be notified by EDMC when something happens: `system_changed()` and `cmdr_data()`.
 
 Your events all get called on the main tkinter loop so be sure not to block for very long or the EDMC will appear to freeze. If you have a long running operation then you should take a look at how to do background updates in tkinter - http://effbot.org/zone/tkinter-threads.htm
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -29,8 +29,11 @@ def plugin_start():
 
 If you want your plugin to be configurable via the GUI you can define a frame (panel) to be displayed on it's own tab in EDMC's settings dialog. Use widgets from EDMC's myNotebook.py for the correct look-and-feel.
 
+You can use `set()`, `get()` and `getint()` from EDMC's config object to store and retrieve your plugin's settings in a platform-independant way.
+
 ```
 import myNotebook as nb
+from config import config
 
 def plugin_prefs(parent):
    """

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -27,44 +27,36 @@ def plugin_start():
 # Plugin Hooks
 ## Configuration 
 
-If you want your plugin to be configurable via the GUI you can define a form (tab) to be used by EDMC's settings window.
+If you want your plugin to be configurable via the GUI you can define a frame (panel) to be displayed on it's own tab in EDMC's settings dialog. Use widgets from EDMC's myNotebook.py for the correct look-and-feel.
 
 ```
-import Tkinter as tk
+import myNotebook as nb
 
 def plugin_prefs(parent):
    """
    Return a TK Frame for adding to the EDMC settings dialog.
    """
-   prefs = tk.Frame(parent)
-   prefs.columnconfigure(1, weight=1)
-   prefs.rowconfigure(2, weight=1)
+   frame = nb.Frame(parent)
+   nb.Label(prefs, text="Hello").grid()
+   nb.Label(prefs, text="Commander").grid()
    
-   tk.Label(prefs, text="Hello").grid(row=0)
-   tk.Label(prefs, text="Commander").grid(row=1)
-   
-   return prefs
+   return frame
 ```
 
 ## Display
 
-You can also have your plugin add an item to the EDMC main window and update it if you need to from your event hooks. This works in the same way as `plugin_prefs()`.
+You can also have your plugin add an item to the EDMC main window and update it if you need to from your event hooks. This works in the same way as `plugin_prefs()`. For a simple one-line item return a ttk.Label widget. For a more complicated item create a ttk.Frame widget and populate it with other ttk widgets.
 
 ```
 def plugin_app(parent):
    """
-   Create a TK frame for the main window
+   Create a TK widget for the EDMC main window
    """
-   status = tk.Frame(parent)
-   status.columnconfigure(2, weight=1)
-   status.rowconfigure(1, weight=1)
+   plugin_app.status = ttk.Label(parent, text="Status:")
+   return plugin_app.status
    
-   tk.Label(status, text="Status:").grid(row=0, column=0)
-   
-   # after this your event functions can directly update plugin_app.status["text"] 
-   plugin_app.status = tk.Label(status, text="Happy!")
-   plugin_app.status.grid(row=0, column=1)
-plugin_app.status = None
+# later on your event functions can directly update plugin_app.status["text"]
+plugin_app.status['text'] = "Status: Happy!"
 ```
 
 ## Events
@@ -72,8 +64,7 @@ plugin_app.status = None
 Once you have created your plugin and EDMC has loaded it there in addition to the `plugin_prefs()` and `plugin_app()` functions there are two other functions you can define to be notified by EDMC when something happens. 
 `system_changed()` and `cmdr_data()`.
 
-Your events all get called on the main tkinter loop so be sure not to block for very long or the EDMC will appear to freeze. If you have a long running operation or wish to update your plugin_app frame from the cmdr_data() event then
-you should take a look at how to do background updates in tkinter - http://effbot.org/zone/tkinter-threads.htm
+Your events all get called on the main tkinter loop so be sure not to block for very long or the EDMC will appear to freeze. If you have a long running operation then you should take a look at how to do background updates in tkinter - http://effbot.org/zone/tkinter-threads.htm
 
 ### Arriving in a System
 
@@ -84,7 +75,7 @@ def system_changed(timestamp, system):
    """
    We arrived at a new system!
    """
-   print "{} {}".format(timestamp, system)
+   sys.stderr.write("{} {}".format(timestamp, system))
 ```
 
 ### Getting Commander Data
@@ -96,7 +87,7 @@ def cmdr_data(data):
    """
    We have new data on our commander
    """
-   print data.get('commander') and data.get('commander').get('name') or ''
+   sys.stderr.write(data.get('commander') and data.get('commander').get('name') or '')
 ```
 
 The data is a dictionary and full of lots of wonderful stuff!

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,12 +1,18 @@
 # EDMC Plugins
 
-Market Connector Plugins allow you to customise and extend the behavior of EDMC. 
+Plugins allow you to customise and extend the behavior of EDMC.
 
 # Writing a Plugin
 
 Plugins are loaded when EDMC starts up.
 
-Plugins are python files. Each plugin has it's own folder in the `plugins` directory. The plugin must have a file named `load.py` that must provide one module level function and optionally provide a few others.
+Each plugin has it's own folder in the `plugins` directory:
+
+* Windows: `%LOCALAPPDATA%\EDMarketConnector\plugins`
+* Mac: `~/Library/Application Support/EDMarketConnector/plugins`
+* Linux: `$XDG_DATA_HOME/EDMarketConnector/plugins`, or `~/.local/share/EDMarketConnector/plugins` if `$XDG_DATA_HOME` is unset.
+
+Plugins are python files. The plugin folder must have a file named `load.py` that must provide one module level function and optionally provide a few others.
 
 EDMC will import the `load.py` file as a module and then call the `plugin_start()` function.
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -93,3 +93,10 @@ def cmdr_data(data):
 ```
 
 The data is a dictionary and full of lots of wonderful stuff!
+
+# Distributing a Plugin
+
+To package your plugin for distribution simply create a `.zip` archive of your plugin's folder:
+
+* Windows: In Explorer right click on your plugin's folder and choose Send to &rarr; Compressed (zipped) folder.
+* Mac: In Finder right click on your plugin's folder and choose Compress.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -40,8 +40,8 @@ def plugin_prefs(parent):
    Return a TK Frame for adding to the EDMC settings dialog.
    """
    frame = nb.Frame(parent)
-   nb.Label(prefs, text="Hello").grid()
-   nb.Label(prefs, text="Commander").grid()
+   nb.Label(frame, text="Hello").grid()
+   nb.Label(frame, text="Commander").grid()
    
    return frame
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ Windows:
 Note: Uninstalling the app does not delete any output files that it has previously written.
 
 
+Plugins
+--------
+Plugins extend the behavior of this app. To install a downloaded plugin, open the `.zip` archive and move the folder contained inside into the following folder:
+
+* Windows: `%LOCALAPPDATA%\EDMarketConnector\plugins` (usually `C:\Users\you\AppData\Local\EDMarketConnector\plugins`).
+* Mac: `~/Library/Application Support/EDMarketConnector/plugins` (in Finder hold ⌥ and choose Go &rarr; Library to open your `~/Library` folder).
+* Linux: `$XDG_DATA_HOME/EDMarketConnector/plugins`, or `~/.local/share/EDMarketConnector/plugins` if `$XDG_DATA_HOME` is unset.
+
+You will need to re-start EDMC for it to notice the new plugin.
+
+Refer to [PLUGINS.md](PLUGINS.md) if you would like to write a plugin.
+
+
 Troubleshooting
 --------
 

--- a/config.py
+++ b/config.py
@@ -89,6 +89,10 @@ class Config:
             if not isdir(self.app_dir):
                 mkdir(self.app_dir)
 
+            self.plugin_dir = join(self.app_dir, 'plugins')
+            if not isdir(self.plugin_dir):
+                mkdir(self.plugin_dir)
+
             self.home = expanduser('~')
 
             if not getattr(sys, 'frozen', False):
@@ -131,6 +135,10 @@ class Config:
             if not isdir(self.app_dir):
                 mkdir(self.app_dir)
             
+            self.plugin_dir = join(self.app_dir, 'plugins')
+            if not isdir(self.plugin_dir):
+                mkdir(self.plugin_dir)
+
             # expanduser in Python 2 on Windows doesn't handle non-ASCII - http://bugs.python.org/issue13207
             ctypes.windll.shell32.SHGetSpecialFolderPathW(0, buf, CSIDL_PROFILE, 0)
             self.home = buf.value
@@ -205,6 +213,10 @@ class Config:
             self.app_dir = join(getenv('XDG_DATA_HOME', expanduser('~/.local/share')), appname)
             if not isdir(self.app_dir):
                 makedirs(self.app_dir)
+
+            self.plugin_dir = join(self.app_dir, 'plugins')
+            if not isdir(self.plugin_dir):
+                mkdir(self.plugin_dir)
 
             self.home = expanduser('~')
 

--- a/plug.py
+++ b/plug.py
@@ -3,6 +3,9 @@ Plugin hooks for EDMC - Ian Norton
 """
 import os
 import imp
+import sys
+
+from config import config
 
 """
 Dictionary of loaded plugin modules.
@@ -16,9 +19,9 @@ def find_plugins():
     :return:
     """
     found = dict()
-    plug_folders = os.listdir("plugins")
+    plug_folders = os.listdir(config.plugin_dir)
     for name in plug_folders:
-        loadfile = os.path.join("plugins", name, "load.py")
+        loadfile = os.path.join(config.plugin_dir, name, "load.py")
         if os.path.isfile(loadfile):
             found[name] = loadfile
     return found
@@ -41,7 +44,7 @@ def load_plugins():
                     PLUGINS[plugname] = plugmod
 
         except Exception as plugerr:
-            print plugerr
+            sys.stderr.write('%s\n' % plugerr)	# appears in %TMP%/EDMarketConnector.log in packaged Windows app
 
     imp.release_lock()
 

--- a/plugins/About/load.py
+++ b/plugins/About/load.py
@@ -2,7 +2,11 @@
 A Skeleton EDMC Plugin
 """
 import sys
+import ttk
 import Tkinter as tk
+
+from config import applongname, appversion
+import myNotebook as nb
 
 
 def plugin_start():
@@ -17,27 +21,28 @@ def plugin_prefs(parent):
     """
     Return a TK Frame for adding to the EDMC settings dialog.
     """
-    prefs = tk.Frame(parent)
-    prefs.columnconfigure(1, weight=1)
-    prefs.rowconfigure(4, weight=1)
+    frame = nb.Frame(parent)
 
-    tk.Label(prefs, text="Elite Dangerous Market Connector").grid(row=0, column=0, sticky=tk.W)
-    tk.Label(prefs, text="Fly Safe!").grid(row=2, column=0, sticky=tk.W)
+    nb.Label(frame, text="{NAME} {VER}".format(NAME=applongname, VER=appversion)).grid(sticky=tk.W)
+    nb.Label(frame).grid()	# spacer
+    nb.Label(frame, text="Fly Safe!").grid(sticky=tk.W)
+    nb.Label(frame).grid()	# spacer
 
     if cmdr_data.last is not None:
         datalen = len(str(cmdr_data.last))
-        tk.Label(prefs, text="FD sent {} chars".format(datalen)).grid(row=3, column=0, sticky=tk.W)
+        nb.Label(frame, text="FD sent {} chars".format(datalen)).grid(sticky=tk.W)
 
-    return prefs
+    return frame
 
 
 def plugin_app(parent):
     """
-    Return a TK Widget for adding to the EDMC main window.
+    Return a TK Widget for the EDMC main window.
     :param parent:
     :return:
     """
-    return tk.Label(parent, text="---")
+    plugin_app.status = ttk.Label(parent, text="---")
+    return plugin_app.status
 
 
 def system_changed(timestamp, system):
@@ -57,6 +62,7 @@ def cmdr_data(data):
     :return:
     """
     cmdr_data.last = data
+    plugin_app.status['text'] = "Got new data ({} chars)".format(len(str(data)))
     sys.stderr.write("Got new data ({} chars)\n".format(len(str(data))))
 
 cmdr_data.last = None

--- a/plugins/About/load.py
+++ b/plugins/About/load.py
@@ -1,6 +1,7 @@
 """
 A Skeleton EDMC Plugin
 """
+import sys
 import Tkinter as tk
 
 
@@ -9,7 +10,7 @@ def plugin_start():
     Start this plugin
     :return:
     """
-    print "example plugin started"
+    sys.stderr.write("example plugin started\n")	# appears in %TMP%/EDMarketConnector.log in packaged Windows app
 
 
 def plugin_prefs(parent):
@@ -46,7 +47,7 @@ def system_changed(timestamp, system):
     :param system: the name of the system
     :return:
     """
-    print "Arrived at {}".format(system)
+    sys.stderr.write("Arrived at {}\n".format(system))
 
 
 def cmdr_data(data):
@@ -56,7 +57,7 @@ def cmdr_data(data):
     :return:
     """
     cmdr_data.last = data
-    print "Got new data ({} chars)".format(len(str(data)))
+    sys.stderr.write("Got new data ({} chars)\n".format(len(str(data))))
 
 cmdr_data.last = None
 

--- a/prefs.py
+++ b/prefs.py
@@ -218,7 +218,11 @@ class PreferencesDialog(tk.Toplevel):
                          _('Keyboard shortcut') or	# Tab heading in settings on OSX
                          _('Hotkey'))			# Tab heading in settings on Windows
 
-
+        # build plugin prefs tabs
+        for plugname in plug.PLUGINS:
+            plugframe = plug.get_plugin_pref(plugname, notebook)
+            if plugframe:
+                notebook.add(plugframe, text=plugname)
 
         if platform=='darwin':
             self.protocol("WM_DELETE_WINDOW", self.apply)	# close button applies changes
@@ -237,12 +241,6 @@ class PreferencesDialog(tk.Toplevel):
 
         # disable hotkey for the duration
         hotkeymgr.unregister()
-
-        # build plugin prefs tabs
-        for plugname in plug.PLUGINS:
-            plugframe = plug.get_plugin_pref(plugname, notebook)
-            if plugframe:
-                notebook.add(plugframe, text=plugname)
 
         # wait for window to appear on screen before calling grab_set
         self.wait_visibility()


### PR DESCRIPTION
Mostly cosmetic and/or documentation.

Except 1647a3b which contains a functional change in the location of the plugins folder: For plugins to be usable by naive users who are using the packaged Windows exe or Mac app and don't want to run from source, plugins need to be loaded from somewhere outside the source tree. On Windows I've chosen `%LOCALAPPDATA%\EDMarketConnector\plugins`, but perhaps there are better places?